### PR TITLE
Update group chat switch on resume

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
@@ -150,6 +150,9 @@ public class MainActivity extends AppCompatActivity {
             enableService(false);
         }
         setSwitchState();
+
+        // set group chat switch state
+        groupReplySwitch.setChecked(preferencesManager.isGroupReplyEnabled());
     }
 
     private void setSwitchState(){


### PR DESCRIPTION
Without this, the switch was always shown as Off whenever user opens the app