### PR TITLE
Reduce min time between replies to 20 seconds

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/NotificationService.java
+++ b/app/src/main/java/com/parishod/watomatic/NotificationService.java
@@ -25,7 +25,7 @@ public class NotificationService extends NotificationListenerService {
     private final String TAG = NotificationService.class.getSimpleName();
     CustomRepliesData customRepliesData;
     private WhatsappAutoReplyLogsDB whatsappAutoReplyLogsDB;
-    private final int DELAY_BETWEEN_REPLY_IN_MILLISEC = 30 * 1000;
+    private final int DELAY_BETWEEN_REPLY_IN_MILLISEC = 20 * 1000;
     private final int DELAY_BETWEEN_NOTIFICATION_RECEIVED_IN_MILLISEC = 60 * 1000;
 
     /*


### PR DESCRIPTION
Idea is to find the time that replies to all human sent messages but only avoid infinite loops. 20 second delay should probably be fine. 20 second delay is also a little too slow for instant messaging. Well it is possible that in some cases it may take longer, but I am confident it breaks the loop at least at 5th or 10th message.

30 sec may result in people complaining that some of the messages are not being auto replied. We can try reducing even further when we have some data.