### PR TITLE
Fix Dark Theme and secondary color in light theme

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,17 +2,13 @@
     <!-- Base application theme. -->
     <style name="Theme.WaReply" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/gray_900</item>
-        <item name="colorPrimaryVariant">@color/gray_800</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimary</item>
-        <!-- Customize your theme here. -->
-        <item name="colorSurface">?attr/colorPrimary</item> <!-- Actionbar color -->
+        <item name="colorPrimary">@color/blue_500</item>
 
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/blue_500</item>
+        <item name="colorSecondaryVariant">@color/blue_900</item>
+
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorSurface</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,11 +4,9 @@
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/blue_500</item>
         <item name="colorPrimaryVariant">@color/blue_700</item>
-        <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/blue_500</item>
+        <item name="colorSecondaryVariant">@color/blue_900</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->


### PR DESCRIPTION
Too many custom theme colors is messing with dark theme. Removed all those and it fixed itself. Also changed secondary color to something similar to primary color set to make checkboxes and switches look consistent

| light | dark | dark editor |
| ---- | ---- | ---- |
|   ![light](https://user-images.githubusercontent.com/2568945/108783457-25081280-7533-11eb-95dc-a4d576ccd560.png)     |    ![dark](https://user-images.githubusercontent.com/2568945/108783480-30f3d480-7533-11eb-83e8-d576896a8969.png)     |     ![dark-editor](https://user-images.githubusercontent.com/2568945/108783791-b37c9400-7533-11eb-8a25-f714a35bf38d.png)      |
