### PR TITLE
Allow users to add Watomatic attribution to user message 

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/NotificationService.java
+++ b/app/src/main/java/com/parishod/watomatic/NotificationService.java
@@ -72,7 +72,7 @@ public class NotificationService extends NotificationListenerService {
         for(RemoteInput remoteIn : notificationWear.getRemoteInputs()){
             remoteInputs[i] = remoteIn;
             // This works. Might need additional parameter to make it for Hangouts? (notification_tag?)
-            localBundle.putCharSequence(remoteInputs[i].getResultKey(), customRepliesData.get());
+            localBundle.putCharSequence(remoteInputs[i].getResultKey(), customRepliesData.getTextToSendOrElse(null));
             i++;
         }
 

--- a/app/src/main/java/com/parishod/watomatic/activity/customreplyeditor/CustomReplyEditorActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/customreplyeditor/CustomReplyEditorActivity.java
@@ -6,18 +6,22 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.Button;
+import android.widget.CheckBox;
 
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.parishod.watomatic.R;
 import com.parishod.watomatic.model.CustomRepliesData;
+import com.parishod.watomatic.model.preferences.PreferencesManager;
 
 public class CustomReplyEditorActivity extends AppCompatActivity {
     TextInputEditText autoReplyText;
     Button saveAutoReplyTextBtn;
     CustomRepliesData customRepliesData;
+    PreferencesManager preferencesManager;
     Button watoMessageLinkBtn;
+    CheckBox appendWatomaticAttribution;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,10 +29,12 @@ public class CustomReplyEditorActivity extends AppCompatActivity {
         setContentView(R.layout.activity_custom_reply_editor);
 
         customRepliesData = CustomRepliesData.getInstance(this);
+        preferencesManager = PreferencesManager.getPreferencesInstance(this);
 
         autoReplyText = findViewById(R.id.autoReplyTextInputEditText);
         saveAutoReplyTextBtn = findViewById(R.id.saveCustomReplyBtn);
         watoMessageLinkBtn = findViewById(R.id.tip_wato_message);
+        appendWatomaticAttribution = findViewById(R.id.appendWatomaticAttribution);
 
         autoReplyText.setText(customRepliesData.get());
         autoReplyText.requestFocus();
@@ -58,6 +64,11 @@ public class CustomReplyEditorActivity extends AppCompatActivity {
             startActivity(
                     new Intent(Intent.ACTION_VIEW).setData(Uri.parse(url))
             );
+        });
+
+        appendWatomaticAttribution.setChecked(preferencesManager.isAppendWatomaticAttributionEnabled());
+        appendWatomaticAttribution.setOnCheckedChangeListener((compoundButton, isChecked) -> {
+            preferencesManager.setAppendWatomaticAttribution(isChecked);
         });
     }
 }

--- a/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
@@ -94,7 +94,7 @@ public class MainActivity extends AppCompatActivity {
         imgPlus = findViewById(R.id.imgPlus);
 
         autoReplyTextPreviewCard.setOnClickListener(this::openCustomReplyEditorActivity);
-        autoReplyTextPreview.setText(customRepliesData.getOrElse(autoReplyTextPlaceholder));
+        autoReplyTextPreview.setText(customRepliesData.getTextToSendOrElse(autoReplyTextPlaceholder));
         // Enable group chat switch only if main switch id ON
         groupReplySwitch.setEnabled(mainAutoReplySwitch.isChecked());
 

--- a/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/main/MainActivity.java
@@ -249,6 +249,9 @@ public class MainActivity extends AppCompatActivity {
 
         // set group chat switch state
         groupReplySwitch.setChecked(preferencesManager.isGroupReplyEnabled());
+
+        // Set user auto reply text
+        autoReplyTextPreview.setText(customRepliesData.getTextToSendOrElse(autoReplyTextPlaceholder));
     }
 
     private void setSwitchState(){

--- a/app/src/main/java/com/parishod/watomatic/model/CustomRepliesData.java
+++ b/app/src/main/java/com/parishod/watomatic/model/CustomRepliesData.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.text.Editable;
 
 import com.parishod.watomatic.R;
+import com.parishod.watomatic.model.preferences.PreferencesManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -22,6 +23,7 @@ public class CustomRepliesData {
     private static SharedPreferences _sharedPrefs;
     private static CustomRepliesData _INSTANCE;
     private Context thisAppContext;
+    private PreferencesManager preferencesManager;
 
     private CustomRepliesData() {}
 
@@ -29,6 +31,7 @@ public class CustomRepliesData {
         thisAppContext = context.getApplicationContext();
         _sharedPrefs = context.getApplicationContext()
                 .getSharedPreferences(APP_SHARED_PREFS, Activity.MODE_PRIVATE);
+        preferencesManager = PreferencesManager.getPreferencesInstance(thisAppContext);
         init();
     }
 
@@ -109,6 +112,16 @@ public class CustomRepliesData {
         return (currentText != null)
                 ? currentText
                 : defaultText;
+    }
+
+    public String getTextToSendOrElse (String defaultTextToSend) {
+        String currentText = get();
+        if (preferencesManager.isAppendWatomaticAttributionEnabled()) {
+            currentText += "\n" + thisAppContext.getString(R.string.sent_using_Watomatic);
+        }
+        return (currentText != null)
+                ? currentText
+                : defaultTextToSend;
     }
 
     private JSONArray getAll() {

--- a/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
+++ b/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
@@ -152,6 +152,7 @@ public class PreferencesManager {
 
     /**
      * Check if it is first install on this device.
+     * ref: https://stackoverflow.com/a/34194960 
      * @param context
      * @return true if first install or else false if it is installed from an update
      */

--- a/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
+++ b/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
@@ -2,6 +2,7 @@ package com.parishod.watomatic.model.preferences;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 
 import androidx.preference.PreferenceManager;
 
@@ -22,6 +23,7 @@ public class PreferencesManager {
     private final String KEY_GROUP_REPLY_ENABLED = "pref_group_reply_enabled";
     private final String KEY_AUTO_REPLY_THROTTLE_TIME_MS = "pref_auto_reply_throttle_time_ms";
     private final String KEY_SELECTED_APPS_ARR = "pref_selected_apps_arr";
+    private final String KEY_IS_APPEND_WATOMATIC_ATTRIBUTION = "pref_is_append_watomatic_attribution";
     private static PreferencesManager _instance;
     private SharedPreferences _sharedPrefs;
     private Context thisAppContext;
@@ -51,6 +53,13 @@ public class PreferencesManager {
                     && !_sharedPrefs.contains(KEY_SELECTED_APPS_ARR);
             if (newInstall) {
                 setAppsAsEnabled(Constants.SUPPORTED_APPS);
+            }
+        }
+
+        if (isFirstInstall(thisAppContext)) {
+            // Set Append Watomatic attribution checked for new installs
+            if (!_sharedPrefs.contains(KEY_IS_APPEND_WATOMATIC_ATTRIBUTION)) {
+                setAppendWatomaticAttribution(true);
             }
         }
     }
@@ -129,5 +138,31 @@ public class PreferencesManager {
             enabledPackages.add(app.getPackageName());
         }
         return serializeAndSetEnabledPackageList(enabledPackages);
+    }
+
+    public void setAppendWatomaticAttribution(boolean enabled) {
+        SharedPreferences.Editor editor = _sharedPrefs.edit();
+        editor.putBoolean(KEY_IS_APPEND_WATOMATIC_ATTRIBUTION, enabled);
+        editor.apply();
+    }
+
+    public boolean isAppendWatomaticAttributionEnabled() {
+        return _sharedPrefs.getBoolean(KEY_IS_APPEND_WATOMATIC_ATTRIBUTION,false);
+    }
+
+    /**
+     * Check if it is first install on this device.
+     * @param context
+     * @return true if first install or else false if it is installed from an update
+     */
+    public static boolean isFirstInstall(Context context) {
+        try {
+            long firstInstallTime = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).firstInstallTime;
+            long lastUpdateTime = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).lastUpdateTime;
+            return firstInstallTime == lastUpdateTime;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            return true;
+        }
     }
 }

--- a/app/src/main/res/layout/activity_custom_reply_editor.xml
+++ b/app/src/main/res/layout/activity_custom_reply_editor.xml
@@ -70,4 +70,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/saveCustomReplyBtn"
         />
+
+    <!-- Append Watomatic Attribution Option -->
+    <CheckBox
+        android:id="@+id/appendWatomaticAttribution"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAlignment="viewStart"
+        android:textColor="?attr/colorControlNormal"
+        android:textSize="12sp"
+        android:text="@string/append_watomatic_arribution_checkbox_label"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+        app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+        app:layout_constraintTop_toBottomOf="@+id/tip_wato_message" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <!-- Custom message editor -->
     <string name="save">Save</string>
     <string name="tip_view_messages_from_fellow_users">Tip: View messages from fellow users for inspiration ➚</string>
+    <string name="append_watomatic_arribution_checkbox_label">Append Watomatic arribution to help spread the word</string>
+    <string name="sent_using_Watomatic">Sent using https://git.io/watomatic</string>
 
     <string name="share_app_text">"I am using Watomatic to break away from WhatsApp. Try it out!\n https://git.io/watomatic</string>
     <string name="share">Share</string>


### PR DESCRIPTION
It should be checked by default ONLY for new installs to preserve behavior for current users.

|  main activity   |   custom editor activity |
| -------------- | ------------------------ |
|       <img width="382" alt="attrib-main" src="https://user-images.githubusercontent.com/2568945/109096117-93d79e00-76e2-11eb-8d01-a396cf7eec07.png">                     |                 <img width="332" alt="attr-editor" src="https://user-images.githubusercontent.com/2568945/109096142-9d610600-76e2-11eb-9e1f-21c7ba450d75.png">                   |

