### PR TITLE
Fix warning icon color while granting permissions

### DIFF
--- a/app/src/main/res/drawable/ic_alert.xml
+++ b/app/src/main/res/drawable/ic_alert.xml
@@ -1,5 +1,5 @@
-<vector android:height="24dp" android:tint="#727272"
+<vector android:height="24dp"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+    <path android:fillColor="@android:color/holo_orange_light" android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
 </vector>


### PR DESCRIPTION
|   light    |        dark        |
| ------- | ------------ |
|       <img width="264" alt="Screen Shot 2021-02-27 at 9 56 02 AM" src="https://user-images.githubusercontent.com/2568945/109392751-7aea0b00-78e3-11eb-8d35-d857ee9b58aa.png">         |    <img width="266" alt="Screen Shot 2021-02-27 at 9 56 21 AM" src="https://user-images.githubusercontent.com/2568945/109392761-863d3680-78e3-11eb-955a-357db900aeb4.png">   |

used orange color instead of the previous gray color which was not showing well on some themes
