### PR TITLE
Fix Android 5 hdpi UI layout -- #147

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true">
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     tools:context=".activity.about.AboutActivity">
 
     <!-- App Title CardView -->
@@ -87,3 +91,4 @@
         app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_custom_reply_editor.xml
+++ b/app/src/main/res/layout/activity_custom_reply_editor.xml
@@ -9,7 +9,7 @@
     <!-- Auto reply text area -->
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/autoReplyTextInputLayout"
-        android:layout_width="378dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/activity_custom_reply_editor.xml
+++ b/app/src/main/res/layout/activity_custom_reply_editor.xml
@@ -7,7 +7,7 @@
     android:fillViewport="true">
 <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     tools:context=".activity.customreplyeditor.CustomReplyEditorActivity">
 
     <!-- Auto reply text area -->

--- a/app/src/main/res/layout/activity_custom_reply_editor.xml
+++ b/app/src/main/res/layout/activity_custom_reply_editor.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".activity.customreplyeditor.CustomReplyEditorActivity">
@@ -84,3 +88,4 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
         app:layout_constraintTop_toBottomOf="@+id/tip_wato_message" />
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".activity.main.MainActivity">
@@ -30,3 +34,4 @@
         app:layout_constraintGuide_end="60dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,7 +7,7 @@
     android:fillViewport="true">
 <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     tools:context=".activity.main.MainActivity">
 
     <androidx.fragment.app.FragmentContainerView

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:fillViewport="true">
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/setting_fragment_container"
@@ -13,3 +18,4 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -76,18 +76,19 @@
 
             <TextView
                 android:id="@+id/textView4"
-                android:layout_width="329dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="3"
                 android:paddingStart="20dp"
-                android:paddingEnd="10dp"
+                android:paddingEnd="20dp"
                 android:paddingBottom="10dp"
                 android:text="@string/mainAutoReplyTextPlaceholder"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView3" />
+                app:layout_constraintTop_toBottomOf="@+id/textView3"
+                />
 
             <ImageView
                 android:id="@+id/imageButton"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -203,50 +203,41 @@
                 app:layout_constraintTop_toBottomOf="@+id/timePickerTitle"/>
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/frequencySetterWidget"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintEnd_toEndOf="parent">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/constraint_inner"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                <ImageView
+                    android:id="@+id/imgMinus"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:src="@drawable/minus"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent">
+                    app:layout_constraintStart_toStartOf="parent"/>
 
-                    <ImageView
-                        android:id="@+id/imgMinus"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:src="@drawable/minus"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"/>
+                <TextView
+                    android:id="@+id/timeSelectedText"
+                    android:layout_width="30dp"
+                    android:layout_height="wrap_content"
+                    android:text="0"
+                    android:textSize="20sp"
+                    android:gravity="center_horizontal"
+                    android:inputType="number"
+                    android:textColor="?attr/colorOnSurface"
+                    app:layout_constraintTop_toTopOf="@+id/imgMinus"
+                    app:layout_constraintBottom_toBottomOf="@id/imgMinus"
+                    app:layout_constraintStart_toEndOf="@+id/imgMinus"/>
 
-                    <TextView
-                        android:id="@+id/timeSelectedText"
-                        android:layout_width="30dp"
-                        android:layout_height="wrap_content"
-                        android:text="0"
-                        android:textSize="20sp"
-                        android:gravity="center_horizontal"
-                        android:inputType="number"
-                        android:textColor="?attr/colorOnSurface"
-                        app:layout_constraintTop_toTopOf="@+id/imgMinus"
-                        app:layout_constraintBottom_toBottomOf="@id/imgMinus"
-                        app:layout_constraintStart_toEndOf="@+id/imgMinus"/>
-
-                    <ImageView
-                        android:id="@+id/imgPlus"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:src="@drawable/plus"
-                        app:layout_constraintStart_toEndOf="@+id/timeSelectedText"
-                        app:layout_constraintTop_toTopOf="parent" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                <ImageView
+                    android:id="@+id/imgPlus"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:src="@drawable/plus"
+                    app:layout_constraintStart_toEndOf="@+id/timeSelectedText"
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Wrap activities in ScrollView to they can be scrolled when they cannot fit on the screen. This fixes layouts for tiny screens and landscape mode
- Remove redundant ConstraintView

fix #147 