### PR TITLE
Include WhatsApp when empty -- #181

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
+++ b/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
@@ -105,7 +105,7 @@ public class PreferencesManager {
         // Users upgrading from v1.7 and before
         // For upgrading users, preserve functionality by enabling only WhatsApp
         //   (remove this when time most users would have updated. May be in 3 weeks after deploying this?)
-        if (enabledAppsJsonStr == null) {
+        if (enabledAppsJsonStr == null || enabledAppsJsonStr.equals("[]")) {
             enabledAppsJsonStr = setAppsAsEnabled(Collections.singleton(new App("WhatsApp", "com.whatsapp")));
         }
 


### PR DESCRIPTION
For existing installs, the app is not including WhatsApp when supported apps are empty.

fix #181 