### PR TITLE
fix link more screenshoots  not found on github page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,12 @@ Watomatic sends an automated reply to everyone contacting you on WhatsApp. This 
 [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="60">](https://f-droid.org/en/packages/com.parishod.watomatic/)
 <a href='https://apt.izzysoft.de/fdroid/index/apk/com.parishod.watomatic'><img alt='Get it on F-Droid via IzzyOnDroid' src='https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png' height="60" /></a>
 
-### [Screenshots](./media/screenshots/)
+### [Screenshots](/screenshots.md)
 
 | [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/1.png" alt="Scr 1">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/2.png" alt="scr 2">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/3.png" alt="Scr 3">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/4.png" alt="Scr 4">][scr-page-link]  |
 | ------------------------------------------- | ------------------------------------------ | ------- | ------ |
 
-[**❯ More screenshots**](./media/screenshots/)
+[**❯ More screenshots**](/screenshots.md)
 
 ### Features:
 - Auto reply to every WhatsApp message

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,20 @@
+[❰ Back to home](/)
+
+# Screenshots | Watomatic
+
+| [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/1.png" alt="Scr 1">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/2.png" alt="scr 2">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/3.png" alt="Scr 3">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/4.png" alt="Scr 4">][scr-page-link]  |
+| ------------------------------------------- | ------------------------------------------ | ------- | ------ |
+
+
+| Light          | Dark        |
+| ------------- | ------------- |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-light-main-pixel3a.png" alt="main screen device light">][scr-page-link]  | [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-dark-main-pixel3a.png" alt="main screen device dark">][scr-page-link] |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-light-editor-pixel3a.png" alt="editor screen device light">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-dark-editor-pixel3a.png" alt="editor screen device dark">][scr-page-link]  |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-whatsapp-chat-pixel3a.png" alt="on whatsapp">][scr-page-link]  |       |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-light-main.png" alt="main screen light">][scr-page-link]  | [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-dark-main.png" alt="main screen dark">][scr-page-link] |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-light-editor.png" alt="editor screen light">][scr-page-link]  |  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-dark-editor.png" alt="editor screen dark">][scr-page-link]  |
+|  [<img src="https://raw.githubusercontent.com/adeekshith/watomatic/main/media/screenshots/wato-1-8-whatsapp-chat.png" alt="on whatsapp">][scr-page-link]  |       |
+
+[❰ Back to home](/)
+
+[scr-page-link]: https://github.com/adeekshith/watomatic/tree/main/media/screenshots


### PR DESCRIPTION
Hi @adeekshith, 
When i'm exploring the Docs on github page, i found link more screenshots was 404 Not Found.
 
In this PR, I try to fix that problem.

![image](https://user-images.githubusercontent.com/18456011/112118656-2cccdc80-8bef-11eb-814a-03c56bc4caad.png)


Thank You 🍻