### PR TITLE
Exclude possible browser intents PR #220

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/fragment/BrandingFragment.java
+++ b/app/src/main/java/com/parishod/watomatic/fragment/BrandingFragment.java
@@ -1,8 +1,10 @@
 package com.parishod.watomatic.fragment;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Patterns;
 import android.view.LayoutInflater;
@@ -32,6 +34,10 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 import static android.content.Intent.ACTION_VIEW;
+import static android.content.Intent.CATEGORY_BROWSABLE;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_REQUIRE_DEFAULT;
+import static android.content.Intent.FLAG_ACTIVITY_REQUIRE_NON_BROWSER;
 
 public class BrandingFragment extends Fragment {
     private ImageButton githubBtn;
@@ -75,6 +81,39 @@ public class BrandingFragment extends Fragment {
     }
 
     private void launchApp() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            launchAppLegacy();
+            return;
+        }
+        boolean isLaunched = false;
+        for (String eachReleaseUrl: whatsNewUrls) {
+            if (isLaunched) { break;}
+            try {
+                // In order for this intent to be invoked, the system must directly launch a non-browser app.
+                // Ref: https://developer.android.com/training/package-visibility/use-cases#avoid-a-disambiguation-dialog
+                Intent intent = new Intent(ACTION_VIEW, Uri.parse(eachReleaseUrl))
+                        .addCategory(CATEGORY_BROWSABLE)
+                        .setFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_REQUIRE_NON_BROWSER |
+                                FLAG_ACTIVITY_REQUIRE_DEFAULT);
+                startActivity(intent);
+                isLaunched = true;
+            } catch (ActivityNotFoundException e) {
+                // This code executes in one of the following cases:
+                // 1. Only browser apps can handle the intent.
+                // 2. The user has set a browser app as the default app.
+                // 3. The user hasn't set any app as the default for handling this URL.
+                isLaunched = false;
+            }
+        }
+        if (!isLaunched) { // Open Github latest release url in browser if everything else fails
+            String url = getString(R.string.watomatic_github_latest_release_url);
+            startActivity (
+                    new Intent(ACTION_VIEW).setData(Uri.parse(url))
+            );
+        }
+    }
+
+    private void launchAppLegacy() {
         boolean isLaunched = false;
         for(String url: whatsNewUrls){
             Intent intent = new Intent(ACTION_VIEW, Uri.parse(url));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="watomatic_github_url" translatable="false">https://github.com/adeekshith/watomatic</string>
     <string name="watomatic_wato_message_url" translatable="false">https://www.reddit.com/r/watomatic/comments/lrkn7j/fellow_watos_share_your_creative_wato_message/</string>
     <string name="watomatic_whatsnew_label"><u>What\'s New?</u></string>
+    <string name="watomatic_github_latest_release_url" translatable="false">https://github.com/adeekshith/watomatic/releases/latest</string>
 
     <!-- Share debug logs -->
     <string name="app_logs_file_name" translatable="false">WatomaticLogs.txt</string>


### PR DESCRIPTION
- Exclude possible browser intents by filtering out intents for generic domain like deekshith.in which does not have any known supported apps
- If no supported intents are found, open Github latest release URL in the default intent (possibly browser)

Merges to PR #220 