### PR TITLE
Add Russian translation

### DIFF
--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -1,12 +1,100 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name">Watomatic</string>
+    <string name="url_privacy_policy" translatable="false">https://adeekshith.github.io/watomatic/#/privacy-policy.md</string>
+    <string name="adeekshith_twitter_handle" translatable="false">\@adeekshith</string>
+    <string name="url_adeekshith_twitter" translatable="false">https://twitter.com/adeekshith</string>
+
+    <string name="about">О приложении</string>
+    <string name="settings">Настройки</string>
+    <string name="privacy_policy_label">Политика конфеденциальности</string>
+    <string name="service_name">Отслеживание уведомлений о входящих сообщениях</string>
+    <string name="mainAutoReplyTextPlaceholder">(Свой ответ)</string>
+    <string name="auto_reply_default_message">Автоматический ответ\n⚠️ Пользователь недоступен</string>
+    <string name="mainAutoReplyLabel">Текст автоматического ответа</string>
+    <string name="mainAutoReplySwitchOffLabel">Автоответ ВЫКЛ</string>
+    <string name="mainAutoReplySwitchOnLabel">Автоответ ВКЛ</string>
+    <string name="mainAutoReplyEditBtnTooltip">Нажмите для редактирования текста автоответа</string>
+    <string name="to_help_you_leave_whatsapp">Автоответчик для облегчения перехода с мессенджеров WhatsApp и Facebook</string>
+    <string name="decline">Отклонить</string>
+    <string name="accept">Разрешить</string>
+    <string name="sure">Да, точно</string>
+    <string name="retry">Повторить</string>
+    <string name="permission_dialog_title">Требуются разрешения</string>
+    <string name="permission_dialog_msg">Для работы приложения необходим доступ к уведомлениям.</string>
+    <string name="permission_dialog_denied_title">Доступ запрещен</string>
+    <string name="permission_dialog_denied_msg">Без данного разрешения приложение не сможет автоматически отвечать на уведомления. Вы точно хотите запретить доступ?</string>
+
     <!-- Select apps to auto reply -->
+    <string name="enable_for_apps">Разрешить для приложений</string>
+    <string name="enable_auto_reply_switch_msg">Сначала включите автоответчик.</string>
+    <string name="error_atleast_single_app_must_be_selected">Ошибка: выберите как минимум одно приложение</string>
+
     <!-- Group chats -->
+    <string name="groupReplySwitchLabel">Автоответ в групповые чаты</string>
+    <string name="group_reply_on_info_message">Включен автоответ в групповые чаты</string>
+    <string name="group_reply_off_info_message">Автоответ в групповые чаты выключен</string>
+
+    <string name="time_picker_title">Частота ответа (БЕТА)</string>
+    <string name="time_picker_sub_title_default">Бесконтрольно отвечать на все сообщения</string>
+    <string name="time_picker_sub_title">Отвечать раз в %1$d дня\/s каждому человеку\/группе</string>
+    <string name="time_format_placeholder">00:00</string>
+    <string name="time_picker_edit_btn_tooltip">Нажмите, чтобы настроить время между ответами</string>
+    <string name="app_version">v%1$s</string>
+
     <!-- Custom message editor -->
+    <string name="save">Сохранить</string>
+    <string name="tip_view_messages_from_fellow_users">🦩 <u>Посмотерть шаблоны сообщений сообщества и поделиться своим ➚</u></string>
+    <string name="append_watomatic_arribution_checkbox_label">Добавить ссылку на Watomatic, чтобы помочь другим</string>
+    <string name="sent_using_Watomatic">Отправлено с помощью git.io/watomatic</string>
+
+    <string name="share_app_text">"Я использую Watomatic для миграции с WhatsApp. Попробуйте и вы!\n https://git.io/watomatic</string>
+    <string name="share">Поделиться</string>
+    <string name="share_subject">Watomatic: Автоответчик для WhatsApp</string>
+    <string name="watomatic_subreddit_label"><u>Обсуждаем\nr/watomatic</u></string>
+    <string name="watomatic_subreddit_url" translatable="false">https://www.reddit.com/r/watomatic</string>
+    <string name="watomatic_github_url" translatable="false">https://github.com/adeekshith/watomatic</string>
+    <string name="watomatic_wato_message_url" translatable="false">https://www.reddit.com/r/watomatic/comments/lrkn7j/fellow_watos_share_your_creative_wato_message/</string>
+    <string name="watomatic_whatsnew_label">Что нового?</string>
+    <string name="watomatic_github_latest_release_url" translatable="false">https://github.com/adeekshith/watomatic/releases/latest</string>
+
     <!-- Share debug logs -->
+    <string name="app_logs_file_name" translatable="false">WatomaticLogs.txt</string>
+    <string name="share_email_body" translatable="false">Hi Team Watomatic,\nPlease find the attachment of the app logs.</string>
+    <string name="share_email_subject" translatable="false">Watomatic AppLogs</string>
+    <string name="share_email_id" translatable="false">watomatic@deekshith.in</string>
+    <string name="share_email_err_msg" translatable="false">Couldnot find any application to process this request</string>
+
     <!-- keys and app internal strings -->
+    <string name="key_pref_app_language" translatable="false">pref_app_language</string>
+    <string name="pref_show_notification_replied_msg" translatable="false">pref_show_notification_replied_msg</string>
+
     <!-- app settings -->
+    <string name="show_notification_label">Показывать уведомления сообщений, на которые отправлен автоматический ответ</string>
+
     <!-- Local language names (non translatable) -->
+    <string name="lang_en" translatable="false">English (en)</string>
+    <string name="lang_de_rDE" translatable="false">Deutsche (de-rDE)</string>
+    <string name="lang_fi_rFI" translatable="false">Suomi (fi_rFI)</string>
+    <string name="lang_fr_rFR" translatable="false">Français (fr-rFR)</string>
+    <string name="lang_in_rID" translatable="false">Indonesian (in-rID)</string>
+    <string name="lang_it_rIT" translatable="false">Italiano (it_rIT)</string>
+    <string name="lang_nl_rNL" translatable="false">Nederlands (nl-rNL)</string>
+    <string name="lang_pt_rBR" translatable="false">Portuguese (pt-rBR)</string>
+    <string name="lang_ta_rIN" translatable="false">தமிழ் (ta-rIN)</string>
+    <string name="lang_de_rDE" translatable="false">Русский (ru-rRU)</string>
+
     <!-- Language codes (non translatable) -->
+    <string name="lang_code_en" translatable="false">en</string>
+    <string name="lang_code_de_rDE" translatable="false">de-rDE</string>
+    <string name="lang_code_fi_rFI" translatable="false">fi-rFI</string>
+    <string name="lang_code_fr_rFR" translatable="false">fr-rFR</string>
+    <string name="lang_code_in_rID" translatable="false">in-rID</string>
+    <string name="lang_code_it_rIT" translatable="false">it-rIT</string>
+    <string name="lang_code_nl_rNL" translatable="false">nl-rNL</string>
+    <string name="lang_code_pt_rBR" translatable="false">pt-rBR</string>
+    <string name="lang_code_ta_rIN" translatable="false">ta-rIN</string>
+    <string name="lang_code_de_rDE" translatable="false">ru-rRU</string>
+
     <!-- App Language selection -->
+    <string name="app_language">Язык приложения</string>
 </resources>


### PR DESCRIPTION
The "Sent using git.io/watomatic" attribution at the end of auto reply message should point to the translated version of the web page. Otherwise it won't cut it.