### PR TITLE
Support deeplink to allow other apps/websites to set Watomatic message

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,14 @@
             android:name="com.parishod.watomatic.activity.customreplyeditor.CustomReplyEditorActivity"
             android:label="@string/mainAutoReplyLabel"
             android:parentActivityName="com.parishod.watomatic.activity.main.MainActivity">
+            <intent-filter android:label="global-auto-reply-message-intent">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "watomatic://auto-reply” -->
+                <data android:scheme="watomatic"
+                    android:host="auto-reply" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/parishod/watomatic/activity/customreplyeditor/CustomReplyEditorActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/customreplyeditor/CustomReplyEditorActivity.java
@@ -35,7 +35,14 @@ public class CustomReplyEditorActivity extends BaseActivity {
         watoMessageLinkBtn = findViewById(R.id.tip_wato_message);
         appendWatomaticAttribution = findViewById(R.id.appendWatomaticAttribution);
 
-        autoReplyText.setText(customRepliesData.get());
+        Intent intent = getIntent();
+        String action = intent.getAction();
+        Uri data = intent.getData();
+
+        autoReplyText.setText ((data != null)
+                ? data.getQueryParameter("message")
+                : customRepliesData.get());
+
         autoReplyText.requestFocus();
         autoReplyText.addTextChangedListener(new TextWatcher() {
             @Override


### PR DESCRIPTION
Support deeplink to allow other apps/websites to set Watomatic message using scheme:
`watomatic://auto-reply?message=<encoded-message>`

To test, can use adb shell to call an intent:
`$ adb shell am start -W -a android.intent.action.VIEW -d "watomatic://auto-reply/?message=Contact%20me%20on%20Xyz%20app.%20My%20id%3A%20999999"`

which asks the user to set a message like this:

![Screenshot_1620359653](https://user-images.githubusercontent.com/2568945/117395864-74b57380-aebe-11eb-9ccb-8ddd9a21901e.png)


Fix #252