### PR TITLE
Fix language changing issues

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/activity/BaseActivity.java
+++ b/app/src/main/java/com/parishod/watomatic/activity/BaseActivity.java
@@ -1,6 +1,7 @@
 package com.parishod.watomatic.activity;
 
 import android.content.Context;
+import android.os.Build;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -14,5 +15,10 @@ public class BaseActivity extends AppCompatActivity {
         PreferencesManager prefs = PreferencesManager.getPreferencesInstance(newBase);
         ContextWrapper contextWrapper = ContextWrapper.wrap(newBase, prefs.getSelectedLocale());
         super.attachBaseContext(contextWrapper);
+
+        //Fix language changing bug on API L to N_MR1, caused by AndroidX
+        //REF: https://stackoverflow.com/a/61572489/5525931
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1)
+            applyOverrideConfiguration(contextWrapper.getResources().getConfiguration());
     }
 }

--- a/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
+++ b/app/src/main/java/com/parishod/watomatic/model/preferences/PreferencesManager.java
@@ -75,6 +75,11 @@ public class PreferencesManager {
                 setAppendWatomaticAttribution(true);
             }
         }
+        else {
+            //If it's first install, language preference is not set, so we don't have to worry
+            //Otherwise, check if language settings contains r, migrate to new language settings key
+            updateLegacyLanguageKey();
+        }
     }
 
     public boolean isServiceEnabled(){
@@ -184,6 +189,12 @@ public class PreferencesManager {
         return _sharedPrefs.getString(KEY_SELECTED_APP_LANGUAGE, defaultLangStr);
     }
 
+    public void setLanguageStr(String languageStr) {
+        SharedPreferences.Editor editor = _sharedPrefs.edit();
+        editor.putString(KEY_SELECTED_APP_LANGUAGE, languageStr);
+        editor.apply();
+    }
+
     public Locale getSelectedLocale () {
         String thisLangStr = getSelectedLanguageStr(null);
         if (thisLangStr == null || thisLangStr.isEmpty()) {
@@ -193,6 +204,20 @@ public class PreferencesManager {
         return (languageSplit.length == 2)
                 ? new Locale(languageSplit[0], languageSplit[1])
                 : new Locale(languageSplit[0]);
+    }
+
+    public void updateLegacyLanguageKey() {
+        String thisLangStr = getSelectedLanguageStr(null);
+        if (thisLangStr == null || thisLangStr.isEmpty()) {
+            return;
+        }
+        String[] languageSplit = thisLangStr.split("-");
+        if (languageSplit.length == 2) {
+            if (languageSplit[1].length() == 3) {
+                String newLangStr = thisLangStr.replace("-r", "-");
+                setLanguageStr(newLangStr);
+            }
+        }
     }
 
     public boolean isShowNotificationEnabled(){

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,22 +92,22 @@
 
     <!-- Language codes (non translatable) -->
     <string name="lang_code_en" translatable="false">en</string>
-    <string name="lang_code_ar_rSA" translatable="false">ar-rSA</string>
-    <string name="lang_code_ca_rES" translatable="false">ca-rES</string>
-    <string name="lang_code_de_rDE" translatable="false">de-rDE</string>
-    <string name="lang_code_es_rES" translatable="false">es-rES</string>
-    <string name="lang_code_es_rMX" translatable="false">es-rMX</string>
-    <string name="lang_code_eu_rES" translatable="false">eu-rES</string>
-    <string name="lang_code_fi_rFI" translatable="false">fi-rFI</string>
-    <string name="lang_code_fr_rFR" translatable="false">fr-rFR</string>
-    <string name="lang_code_in_rID" translatable="false">in-rID</string>
-    <string name="lang_code_it_rIT" translatable="false">it-rIT</string>
-    <string name="lang_code_mk_rMK" translatable="false">mk-rMK</string>
-    <string name="lang_code_nl_rNL" translatable="false">nl-rNL</string>
-    <string name="lang_code_pt_rBR" translatable="false">pt-rBR</string>
-    <string name="lang_code_ru_rRU" translatable="false">ru-rRU</string>
-    <string name="lang_code_ta_rIN" translatable="false">ta-rIN</string>
-    <string name="lang_code_tr_rTR" translatable="false">tr-rTR</string>
+    <string name="lang_code_ar_rSA" translatable="false">ar-SA</string>
+    <string name="lang_code_ca_rES" translatable="false">ca-ES</string>
+    <string name="lang_code_de_rDE" translatable="false">de-DE</string>
+    <string name="lang_code_es_rES" translatable="false">es-ES</string>
+    <string name="lang_code_es_rMX" translatable="false">es-MX</string>
+    <string name="lang_code_eu_rES" translatable="false">eu-ES</string>
+    <string name="lang_code_fi_rFI" translatable="false">fi-FI</string>
+    <string name="lang_code_fr_rFR" translatable="false">fr-FR</string>
+    <string name="lang_code_in_rID" translatable="false">in-ID</string>
+    <string name="lang_code_it_rIT" translatable="false">it-IT</string>
+    <string name="lang_code_mk_rMK" translatable="false">mk-MK</string>
+    <string name="lang_code_nl_rNL" translatable="false">nl-NL</string>
+    <string name="lang_code_pt_rBR" translatable="false">pt-BR</string>
+    <string name="lang_code_ru_rRU" translatable="false">ru-RU</string>
+    <string name="lang_code_ta_rIN" translatable="false">ta-IN</string>
+    <string name="lang_code_tr_rTR" translatable="false">tr-TR</string>
 
     <!-- App Language selection -->
     <string name="app_language">App Language</string>


### PR DESCRIPTION
Fix for locale changing issues, possible fix #270, tested on Android Emulator API 21 (previously not working, now it does), as well as API 29 and 30 on physical devices, both working.

When creating locales, region code must be a 2 alpha character string as explained [here](https://developer.android.com/reference/java/util/Locale), I imagine the r added on resource folder is an abbreviation for region and should not be used when creating Locales in code.

Also, a bug on AndroidX compat library causes the locale to be overridden to default on API versions 21 to 25 because of DayNight compatibility, so applyOverrideConfiguration must be called with the new context created.