### PR TITLE
Prevent crash on contact selector when no contacts on device

### DIFF
--- a/app/src/main/java/com/parishod/watomatic/model/utils/ContactsHelper.java
+++ b/app/src/main/java/com/parishod/watomatic/model/utils/ContactsHelper.java
@@ -91,13 +91,16 @@ public class ContactsHelper {
         Cursor cursor = contentResolver.query(ContactsContract.Data.CONTENT_URI, queryColumnAttribute, null, null, ContactsContract.Contacts.SORT_KEY_PRIMARY + " ASC");
 
         if (cursor != null) {
-            cursor.moveToFirst();
-            do {
-                int columnIndex = cursor.getColumnIndex(ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY);
-                String contactName = cursor.getString(columnIndex);
-                boolean contactChecked = previousSelectedContacts.contains(contactName);
-                contactList.add(new ContactHolder(contactName, contactChecked));
-            } while (cursor.moveToNext());
+            if (cursor.moveToFirst()) {
+                do {
+                    int columnIndex = cursor.getColumnIndex(ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY);
+                    String contactName = cursor.getString(columnIndex);
+                    if (contactName != null && !contactName.isEmpty()) {
+                        boolean contactChecked = previousSelectedContacts.contains(contactName);
+                        contactList.add(new ContactHolder(contactName, contactChecked));
+                    }
+                } while (cursor.moveToNext());
+            }
         }
 
         if (cursor != null) {


### PR DESCRIPTION
App was crashing when opening the contact selector and there were no contacts on device. Also no longer showing an empty contact at the end of the list (at least, it was happening for me) which was a null string, potentially preventing more errors.