### PR TITLE
Disable jetifier for better build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false


### PR DESCRIPTION
Disable jetifier as we do not have any dependencies that do not support androidx natively.

(Android studio recommendation)